### PR TITLE
Fix Python3 compatibility in fixpaths

### DIFF
--- a/src/po/fixpaths.py
+++ b/src/po/fixpaths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import getopt
 import os
 import string
@@ -15,5 +15,6 @@ def quote(n):
     return "'%s'" % n.replace("'", "'\\''")
 
 for fn in args:
-    if join: fn = os.path.join(join, fn)
-    print(quote(os.path.normpath(fn))).encode('ascii')
+    if join:
+        fn = os.path.join(join, fn)
+    sys.stdout.buffer.write(quote(os.path.normpath(fn)).encode('ascii') + b"\n")


### PR DESCRIPTION
## Summary
- ensure src/po/fixpaths.py works with Python3
- output ASCII data correctly

## Testing
- `scripts/runtests tests/abs.0` *(fails: /workspace/linuxcnc/scripts/rip-environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bb0e68408324a010c477caebfa37